### PR TITLE
Update for MO2 2.5.0

### DIFF
--- a/lootconfigloader/lootconfigmapper.py
+++ b/lootconfigloader/lootconfigmapper.py
@@ -1,5 +1,4 @@
 import os
-from distutils.version import LooseVersion
 from typing import List
 from mobase import (
     IOrganizer,
@@ -58,12 +57,12 @@ class LOOTConfigMapper(IPluginFileMapper):
         return Mapping(source, destination, is_directory=True, create_target=False)
 
     def finish_init(self, window: QMainWindow) -> None:
-        mo2version = LooseVersion(self.organizer.appVersion().canonicalString())
+        mo2version = self.organizer.appVersion()
         source = self.get_source_path()
         os.makedirs(source, exist_ok=True)
 
         destination = self.get_destination_path()
-        if mo2version >= LooseVersion("2.5.0.0"):
+        if mo2version >= VersionInfo(2, 5, 0):
             destination = os.path.join(destination, "games")
         game_name = self.organizer.managedGame().gameName()
         os.makedirs(os.path.join(destination, game_name), exist_ok=True)

--- a/lootconfigloader/lootconfigmapper.py
+++ b/lootconfigloader/lootconfigmapper.py
@@ -8,11 +8,14 @@ from mobase import (
     ReleaseType,
     VersionInfo,
 )
-from PyQt5.QtWidgets import QMainWindow
+
+try:
+    from PyQt5.QtWidgets import QMainWindow
+except ImportError:
+    from PyQt6.QtWidgets import QMainWindow
 
 
 class LOOTConfigMapper(IPluginFileMapper):
-
     def __init__(self):
         super().__init__()
 
@@ -51,10 +54,7 @@ class LOOTConfigMapper(IPluginFileMapper):
     def make_loot_mapping(self) -> "Mapping":
         source = self.get_source_path()
         destination = self.get_destination_path()
-        return Mapping(source,
-                       destination,
-                       is_directory=True,
-                       create_target=False)
+        return Mapping(source, destination, is_directory=True, create_target=False)
 
     def finish_init(self, window: QMainWindow) -> None:
         source = self.get_source_path()
@@ -62,4 +62,7 @@ class LOOTConfigMapper(IPluginFileMapper):
 
         destination = self.get_destination_path()
         game_name = self.organizer.managedGame().gameName()
-        os.makedirs(os.path.join(destination, game_name), exist_ok=True)
+        os.makedirs(
+            os.path.join(os.path.join(destination, "games"), game_name),
+            exist_ok=True,
+        )

--- a/lootconfigloader/lootconfigmapper.py
+++ b/lootconfigloader/lootconfigmapper.py
@@ -1,4 +1,5 @@
 import os
+from distutils.version import LooseVersion
 from typing import List
 from mobase import (
     IOrganizer,
@@ -57,12 +58,12 @@ class LOOTConfigMapper(IPluginFileMapper):
         return Mapping(source, destination, is_directory=True, create_target=False)
 
     def finish_init(self, window: QMainWindow) -> None:
+        mo2version = LooseVersion(self.organizer.appVersion().canonicalString())
         source = self.get_source_path()
         os.makedirs(source, exist_ok=True)
 
         destination = self.get_destination_path()
+        if mo2version >= LooseVersion("2.5.0.0"):
+            destination = os.path.join(destination, "games")
         game_name = self.organizer.managedGame().gameName()
-        os.makedirs(
-            os.path.join(os.path.join(destination, "games"), game_name),
-            exist_ok=True,
-        )
+        os.makedirs(os.path.join(destination, game_name), exist_ok=True)


### PR DESCRIPTION
Fix PyQt import and LOOT game folder path for the latest versions of MO2 (2.5.0) and LOOT (> 0.18): 

- Import PyQt6 instead of PyQt5 since MO2 2.5.0 ships PyQt6.
- Create game dir in `%LOCALAPPDATA%/LOOT/games`. Game folders have been moved to `games` subfolder [in 0.18.0](https://loot.readthedocs.io/en/latest/app/changelog.html#id52).